### PR TITLE
fix: unable to trigger when "Long press the home button" is set to "None" in Button shortcuts

### DIFF
--- a/app/src/main/java/com/parallelc/micts/hooker/LongPressHomeHooker.kt
+++ b/app/src/main/java/com/parallelc/micts/hooker/LongPressHomeHooker.kt
@@ -23,34 +23,18 @@ class LongPressHomeHooker {
         @SuppressLint("PrivateApi")
         fun hook(param: SystemServerLoadedParam) {
             val miuiSingleKeyRule = param.classLoader.loadClass("com.android.server.policy.MiuiSingleKeyRule")
-            module!!.hook(
-                miuiSingleKeyRule.getDeclaredMethod("supportLongPress"),
-                SupportLongPressHooker::class.java
-            )
-            module!!.hook(
-                miuiSingleKeyRule.getDeclaredMethod("onLongPress", Long::class.java),
-                OnLongPressHooker::class.java
-            )
             mContext = miuiSingleKeyRule.getDeclaredField("mContext")
             mContext.isAccessible = true
             mKeyCode = miuiSingleKeyRule.getDeclaredField("mKeyCode")
             mKeyCode.isAccessible = true
-        }
-
-        @XposedHooker
-        class SupportLongPressHooker : Hooker {
-            companion object {
-                @JvmStatic
-                @BeforeInvocation
-                fun before(callback: BeforeHookCallback) {
-                    if (mKeyCode.getInt(callback.thisObject) == 3) {
-                        val prefs = module!!.getRemotePreferences(CONFIG_NAME)
-                        if (prefs.getBoolean(KEY_HOME_TRIGGER, DEFAULT_CONFIG[KEY_HOME_TRIGGER] as Boolean)) {
-                            callback.returnAndSkip(true)
-                        }
-                    }
-                }
-            }
+            module!!.hook(
+                miuiSingleKeyRule.getDeclaredMethod("onLongPress", Long::class.java),
+                OnLongPressHooker::class.java
+            )
+            module!!.hook(
+                miuiSingleKeyRule.getDeclaredMethod("supportLongPress"),
+                SupportLongPressHooker::class.java
+            )
         }
 
         @XposedHooker
@@ -70,6 +54,22 @@ class LongPressHomeHooker {
                             )
                             callback.returnAndSkip(null)
                         }
+                    }
+                }
+            }
+        }
+    }
+
+    @XposedHooker
+    class SupportLongPressHooker : Hooker {
+        companion object {
+            @JvmStatic
+            @BeforeInvocation
+            fun before(callback: BeforeHookCallback) {
+                if (mKeyCode.getInt(callback.thisObject) == 3) {
+                    val prefs = module!!.getRemotePreferences(CONFIG_NAME)
+                    if (prefs.getBoolean(KEY_HOME_TRIGGER, DEFAULT_CONFIG[KEY_HOME_TRIGGER] as Boolean)) {
+                        callback.returnAndSkip(true)
                     }
                 }
             }

--- a/app/src/main/java/com/parallelc/micts/hooker/LongPressHomeHooker.kt
+++ b/app/src/main/java/com/parallelc/micts/hooker/LongPressHomeHooker.kt
@@ -1,7 +1,7 @@
 package com.parallelc.micts.hooker
 
+import android.annotation.SuppressLint
 import android.content.Context
-import android.os.Bundle
 import com.parallelc.micts.config.XposedConfig.CONFIG_NAME
 import com.parallelc.micts.config.XposedConfig.DEFAULT_CONFIG
 import com.parallelc.micts.config.XposedConfig.KEY_HOME_TRIGGER
@@ -18,34 +18,57 @@ import java.lang.reflect.Field
 class LongPressHomeHooker {
     companion object {
         private lateinit var mContext: Field
+        private lateinit var mKeyCode: Field
 
+        @SuppressLint("PrivateApi")
         fun hook(param: SystemServerLoadedParam) {
-            val shortCutActionsUtils = param.classLoader.loadClass("com.miui.server.input.util.ShortCutActionsUtils")
+            val miuiSingleKeyRule = param.classLoader.loadClass("com.android.server.policy.MiuiSingleKeyRule")
             module!!.hook(
-                shortCutActionsUtils.getDeclaredMethod("triggerFunction", String::class.java, String::class.java, Bundle::class.java, Boolean::class.java, String::class.java),
-                TriggerFunctionHooker::class.java
+                miuiSingleKeyRule.getDeclaredMethod("supportLongPress"),
+                SupportLongPressHooker::class.java
             )
-            mContext = shortCutActionsUtils.getDeclaredField("mContext")
+            module!!.hook(
+                miuiSingleKeyRule.getDeclaredMethod("onLongPress", Long::class.java),
+                OnLongPressHooker::class.java
+            )
+            mContext = miuiSingleKeyRule.getDeclaredField("mContext")
             mContext.isAccessible = true
+            mKeyCode = miuiSingleKeyRule.getDeclaredField("mKeyCode")
+            mKeyCode.isAccessible = true
         }
 
         @XposedHooker
-        class TriggerFunctionHooker : Hooker {
+        class SupportLongPressHooker : Hooker {
             companion object {
                 @JvmStatic
                 @BeforeInvocation
                 fun before(callback: BeforeHookCallback) {
-                    if (callback.args[1] == "long_press_home_key" || callback.args[1] == "long_press_home_key_no_ui") {
+                    if (mKeyCode.getInt(callback.thisObject) == 3) {
+                        val prefs = module!!.getRemotePreferences(CONFIG_NAME)
+                        if (prefs.getBoolean(KEY_HOME_TRIGGER, DEFAULT_CONFIG[KEY_HOME_TRIGGER] as Boolean)) {
+                            callback.returnAndSkip(true)
+                        }
+                    }
+                }
+            }
+        }
+
+        @XposedHooker
+        class OnLongPressHooker : Hooker {
+            companion object {
+                @JvmStatic
+                @BeforeInvocation
+                fun before(callback: BeforeHookCallback) {
+                    if (mKeyCode.getInt(callback.thisObject) == 3) {
                         val prefs = module!!.getRemotePreferences(CONFIG_NAME)
                         if (prefs.getBoolean(KEY_HOME_TRIGGER, DEFAULT_CONFIG[KEY_HOME_TRIGGER] as Boolean)) {
                             val context = runCatching { mContext.get(callback.thisObject) as? Context }.getOrNull()
-                            callback.returnAndSkip(
-                                triggerCircleToSearch(
-                                    1,
-                                    context,
-                                    prefs.getBoolean(KEY_VIBRATE, DEFAULT_CONFIG[KEY_VIBRATE] as Boolean)
-                                )
+                            triggerCircleToSearch(
+                                1,
+                                context,
+                                prefs.getBoolean(KEY_VIBRATE, DEFAULT_CONFIG[KEY_VIBRATE] as Boolean)
                             )
+                            callback.returnAndSkip(null)
                         }
                     }
                 }


### PR DESCRIPTION
### **User description**
may fix #59


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix home button long press not triggering when set to "None"
  - Now hooks `onLongPress` and `supportLongPress` in `MiuiSingleKeyRule`
  - Ensures assistant triggers even if shortcut is "None"

- Refactor hook logic for robustness and maintainability
  - Uses key code check instead of action string
  - Adds support for long press detection logic


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LongPressHomeHooker.kt</strong><dd><code>Refactor and fix home button long press trigger logic</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/src/main/java/com/parallelc/micts/hooker/LongPressHomeHooker.kt

<li>Switches hook target from <code>ShortCutActionsUtils.triggerFunction</code> to <br><code>MiuiSingleKeyRule.onLongPress</code> and <code>supportLongPress</code><br> <li> Adds key code-based logic to detect home button long press<br> <li> Implements new hook class for <code>supportLongPress</code> to ensure feature <br>availability<br> <li> Refactors code for improved robustness and clarity


</details>


  </td>
  <td><a href="https://github.com/parallelcc/MiCTS/pull/68/files#diff-178075f75ae693ad72c00517c821cc7d155f2cc8897a0e266535d97dc8d6c7a2">+38/-15</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>