### PR TITLE
Add "Long press the home button" for meizu devices

### DIFF
--- a/app/src/main/java/com/parallelc/micts/ModuleMain.kt
+++ b/app/src/main/java/com/parallelc/micts/ModuleMain.kt
@@ -13,6 +13,7 @@ import com.parallelc.micts.config.XposedConfig.KEY_SPOOF_MODEL
 import com.parallelc.micts.hooker.CSMSHooker
 import com.parallelc.micts.hooker.InvokeOmniHooker
 import com.parallelc.micts.hooker.LongPressHomeHooker
+import com.parallelc.micts.hooker.NavBarActionsConfigHooker
 import com.parallelc.micts.hooker.NavStubGestureEventManagerHooker
 import com.parallelc.micts.hooker.NavStubViewHooker
 import com.parallelc.micts.hooker.VIMSHooker
@@ -100,6 +101,14 @@ class ModuleMain(base: XposedInterface, param: ModuleLoadedParam) : XposedModule
                 val DEVICE = buildClass.getDeclaredField("DEVICE")
                 DEVICE.isAccessible = true
                 DEVICE.set(null, prefs.getString(KEY_SPOOF_DEVICE, DEFAULT_CONFIG[KEY_SPOOF_DEVICE] as String))
+            }
+            "com.android.systemui" -> {
+                if (Build.MANUFACTURER != "meizu") return
+                runCatching {
+                    NavBarActionsConfigHooker.hook(param)
+                }.onFailure { e ->
+                    log("hook NavBarActionsConfig fail", e)
+                }
             }
         }
     }

--- a/app/src/main/java/com/parallelc/micts/config/XposedConfig.kt
+++ b/app/src/main/java/com/parallelc/micts/config/XposedConfig.kt
@@ -40,7 +40,7 @@ object XposedConfig {
     val DEFAULT_CONFIG = mapOf<String, Any>(
         KEY_TRIGGER_SERVICE to TriggerService.getSupportedServices().last().ordinal,
         KEY_GESTURE_TRIGGER to (Build.MANUFACTURER == "Xiaomi"),
-        KEY_HOME_TRIGGER to (Build.MANUFACTURER == "Xiaomi"),
+        KEY_HOME_TRIGGER to (Build.MANUFACTURER == "Xiaomi" || Build.MANUFACTURER == "meizu"),
         KEY_DEVICE_SPOOF to true,
         KEY_SPOOF_MANUFACTURER to "Google",
         KEY_SPOOF_BRAND to "google",

--- a/app/src/main/java/com/parallelc/micts/hooker/NavBarActionsConfigHooker.kt
+++ b/app/src/main/java/com/parallelc/micts/hooker/NavBarActionsConfigHooker.kt
@@ -1,0 +1,51 @@
+package com.parallelc.micts.hooker
+
+import android.content.Context
+import com.parallelc.micts.config.XposedConfig.CONFIG_NAME
+import com.parallelc.micts.config.XposedConfig.DEFAULT_CONFIG
+import com.parallelc.micts.config.XposedConfig.KEY_HOME_TRIGGER
+import com.parallelc.micts.config.XposedConfig.KEY_VIBRATE
+import com.parallelc.micts.module
+import com.parallelc.micts.ui.activity.triggerCircleToSearch
+import io.github.libxposed.api.XposedInterface.BeforeHookCallback
+import io.github.libxposed.api.XposedInterface.Hooker
+import io.github.libxposed.api.XposedModuleInterface.PackageLoadedParam
+import io.github.libxposed.api.annotations.BeforeInvocation
+import io.github.libxposed.api.annotations.XposedHooker
+
+class NavBarActionsConfigHooker {
+    companion object {
+        fun hook(param: PackageLoadedParam) {
+            val navBarActionsConfig =
+                param.classLoader.loadClass("com.flyme.systemui.navigationbar.actions.NavBarActionsConfig")
+            module!!.hook(
+                navBarActionsConfig.getDeclaredMethod(
+                    "helpStartAI",
+                    Context::class.java,
+                    String::class.java
+                ),
+                HelpStartAiHooker::class.java
+            )
+        }
+    }
+
+    @XposedHooker
+    class HelpStartAiHooker : Hooker {
+        companion object {
+            @JvmStatic
+            @BeforeInvocation
+            fun before(callback: BeforeHookCallback) {
+                val prefs = module!!.getRemotePreferences(CONFIG_NAME)
+                if (!prefs.getBoolean(KEY_HOME_TRIGGER, DEFAULT_CONFIG[KEY_HOME_TRIGGER] as Boolean)) {
+                    return
+                }
+                triggerCircleToSearch(
+                    1,
+                    callback.args[0] as? Context,
+                    prefs.getBoolean(KEY_VIBRATE, DEFAULT_CONFIG[KEY_VIBRATE] as Boolean)
+                )
+                callback.returnAndSkip(null)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/parallelc/micts/ui/activity/SettingsActivity.kt
+++ b/app/src/main/java/com/parallelc/micts/ui/activity/SettingsActivity.kt
@@ -335,7 +335,7 @@ fun SettingsPage(
         }
 
         val isXiaomi = Build.MANUFACTURER == "Xiaomi"
-        val isMeizu = Build.MANUFACTURER == "Meizu"
+        val isMeizu = Build.MANUFACTURER == "meizu"
         if (isXiaomi) {
             ListItem(
                 headlineContent = { Text(stringResource(R.string.trigger_by_long_press_gesture_handle)) },

--- a/app/src/main/java/com/parallelc/micts/ui/activity/SettingsActivity.kt
+++ b/app/src/main/java/com/parallelc/micts/ui/activity/SettingsActivity.kt
@@ -334,7 +334,9 @@ fun SettingsPage(
             )
         }
 
-        if (Build.MANUFACTURER == "Xiaomi") {
+        val isXiaomi = Build.MANUFACTURER == "Xiaomi"
+        val isMeizu = Build.MANUFACTURER == "Meizu"
+        if (isXiaomi) {
             ListItem(
                 headlineContent = { Text(stringResource(R.string.trigger_by_long_press_gesture_handle)) },
                 trailingContent = {
@@ -344,7 +346,9 @@ fun SettingsPage(
                     )
                 }
             )
+        }
 
+        if (isXiaomi || isMeizu) {
             ListItem(
                 headlineContent = { Text(stringResource(R.string.trigger_by_long_press_home_button)) },
                 trailingContent = {

--- a/app/src/main/java/com/parallelc/micts/ui/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/parallelc/micts/ui/viewmodel/SettingsViewModel.kt
@@ -123,6 +123,9 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                 if (Build.BRAND == "POCO" && scope.contains("com.mi.android.globallauncher") == false) {
                     _xposedService.value?.requestScope("com.mi.android.globallauncher", object: OnScopeEventListener{})
                 }
+                if (Build.MANUFACTURER == "meizu" && scope.contains("com.android.systemui") == false) {
+                    _xposedService.value?.requestScope("com.android.systemui", object : OnScopeEventListener {})
+                }
             }
             XposedConfig.KEY_DEVICE_SPOOF -> {
                 if (scope.contains("com.google.android.googlequicksearchbox") == false) {


### PR DESCRIPTION
### **User description**
Similar to Xiaomi, home button will trigger MiCTS

Can be work on both Navigation bar (mBack must be enabled) and Android navigation bar.
But need to activate it on Aicy Voice > Navigation key wake up. Else button will trigger home action or Gemini.

Tested on Flyme 12 AIOS (Android 15)


___

### **PR Type**
Enhancement


___

### **Description**
- Add Meizu device support for home button trigger

- Create new hooker for Meizu navigation bar actions

- Update configuration to include Meizu manufacturer

- Add system UI scope request for Meizu devices


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Meizu Device Detection"] --> B["NavBarActionsConfigHooker"]
  B --> C["Hook helpStartAI Method"]
  C --> D["Trigger Circle to Search"]
  E["Settings UI"] --> F["Enable Home Trigger"]
  F --> G["Request SystemUI Scope"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ModuleMain.kt</strong><dd><code>Add Meizu systemui hooking support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/src/main/java/com/parallelc/micts/ModuleMain.kt

<ul><li>Import new <code>NavBarActionsConfigHooker</code> class<br> <li> Add Meizu-specific hook for <code>com.android.systemui</code> package<br> <li> Include manufacturer check for Meizu devices</ul>


</details>


  </td>
  <td><a href="https://github.com/parallelcc/MiCTS/pull/117/files#diff-b8f1b1fef1b8b424645cefa7a7fda03de1534488be81574f8a6739fd13caa0f1">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>NavBarActionsConfigHooker.kt</strong><dd><code>New Meizu navigation bar hooker implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/src/main/java/com/parallelc/micts/hooker/NavBarActionsConfigHooker.kt

<ul><li>Create new hooker class for Meizu navigation bar actions<br> <li> Hook <code>helpStartAI</code> method to intercept and trigger circle search<br> <li> Implement configuration checks and vibration support</ul>


</details>


  </td>
  <td><a href="https://github.com/parallelcc/MiCTS/pull/117/files#diff-1e00baecf312465bb8015c7f2ebec6466934721b40b06067f483c46322c5e142">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SettingsActivity.kt</strong><dd><code>Update settings UI for Meizu support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/src/main/java/com/parallelc/micts/ui/activity/SettingsActivity.kt

<ul><li>Add Meizu manufacturer detection variables<br> <li> Update UI logic to show home trigger option for both Xiaomi and Meizu<br> <li> Separate gesture and home trigger settings display logic</ul>


</details>


  </td>
  <td><a href="https://github.com/parallelcc/MiCTS/pull/117/files#diff-21e0eb540f48b962ec00c4fcdeda2fb99e730eeaeb0d0f77bc413cd0c3cb0585">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SettingsViewModel.kt</strong><dd><code>Add Meizu scope management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/src/main/java/com/parallelc/micts/ui/viewmodel/SettingsViewModel.kt

<ul><li>Add scope request for <code>com.android.systemui</code> when Meizu home trigger is <br>enabled<br> <li> Include Meizu manufacturer check in configuration update logic</ul>


</details>


  </td>
  <td><a href="https://github.com/parallelcc/MiCTS/pull/117/files#diff-e9cc650b7b96271bc01a0244bf93f4cda784a132c8220e37dc22cf83c1e25591">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>XposedConfig.kt</strong><dd><code>Enable home trigger for Meizu devices</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/src/main/java/com/parallelc/micts/config/XposedConfig.kt

<ul><li>Update <code>KEY_HOME_TRIGGER</code> default config to include Meizu manufacturer<br> <li> Enable home trigger by default for both Xiaomi and Meizu devices</ul>


</details>


  </td>
  <td><a href="https://github.com/parallelcc/MiCTS/pull/117/files#diff-b152feaa3b415d69beff773e19922dda4caa11d308e8238ed9e7eadb0e85ae63">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

